### PR TITLE
update on snackbar with link

### DIFF
--- a/dist/snackbarlight.css
+++ b/dist/snackbarlight.css
@@ -40,6 +40,9 @@
     border-radius: 0;
     margin-bottom: 0;
   }
+  .snackbar.active > a {
+	margin-right: 40px;
+  }
 }
 .snackbar {
   background-color: #323232;


### PR DESCRIPTION
Added margin-right for Snackbar with link in @media (max-width: 767px).
 In smaller devices button goes out of box at the right side. This is now fixed.
